### PR TITLE
fix(ci): resolve CI pipeline failures - RGBA icons and gem permissions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,3 @@
-name: Auto Labeler
-
 # Labels for different file changes
 frontend:
   - changed-files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
         working-directory: src-tauri
         run: cargo fmt --all -- --check
 
+      - name: Create dist directory for Tauri context
+        run: mkdir -p dist
+
       - name: Run Clippy linter
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
@@ -175,6 +178,9 @@ jobs:
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
+
+      - name: Create dist directory for Tauri context
+        run: mkdir -p dist
 
       - name: Run security audit
         working-directory: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install Ruby and fpm for RPM conversion
         run: |
           sudo apt-get install -y ruby ruby-dev
-          gem install fpm
+          sudo gem install fpm
 
       - name: Build RPM package
         run: ./scripts/build-rpm.sh
@@ -269,7 +269,7 @@ jobs:
       - name: Install Ruby and fpm for RPM conversion
         run: |
           sudo apt-get install -y ruby ruby-dev
-          gem install fpm
+          sudo gem install fpm
 
       - name: Build RPM package
         run: ./scripts/build-rpm.sh


### PR DESCRIPTION
## Summary

Fixes all 3 CI pipeline failures:

### 1. Tauri Build - Icon not RGBA
```
error: icon src-tauri/icons/32x32.png is not RGBA
```
**Fix:** All PNG icons in `src-tauri/icons/` converted from RGB to RGBA format (32x32, 128x128, 256x256, 512x512).

### 2. Ruby Gem Permission Error
```
ERROR: While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for /var/lib/gems/3.0.0 directory.
```
**Fix:** Changed `gem install fpm` to `sudo gem install fpm` in both `build-tauri` and `integration-test` CI jobs.

### 3. Prettier / Rustfmt Formatting (fixed in prior commit on main)
- Ran `prettier --write` on 3 frontend files
- Fixed `cargo fmt` violations in `updater.rs`

## Checklist
- [x] All PNG icons verified as RGBA
- [x] `sudo gem install fpm` in both CI jobs
- [x] Prettier and rustfmt checks pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline reliability by ensuring build artifact directories are created and packaging steps run with required privileges, reducing intermittent build/package failures.
  * Removed a top-level labeler metadata key from repository labeling config to simplify label definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->