### PR TITLE
feat: implement custom APT repository via GitHub Pages architecture

### DIFF
--- a/.github/workflows/apt-repo.yml
+++ b/.github/workflows/apt-repo.yml
@@ -1,0 +1,115 @@
+name: Deploy APT Repository
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch repository debs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p public/apt/pool/main
+          # Ensure gh cli operates non-interactively
+          gh release list --limit 10 | awk '{print $1}' > releases.txt
+          while read -r tag; do
+            echo "Fetching deb packages for release $tag"
+            gh release download "$tag" --pattern "*.deb" --dir public/apt/pool/main/ --clobber || echo "No deb found for $tag"
+          done < releases.txt
+          
+          if [ ! "$(ls -A public/apt/pool/main/*.deb 2>/dev/null)" ]; then
+            echo "No .deb files found to publish!"
+            exit 1
+          fi
+
+      - name: Setup APT Metadata
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev apt-utils
+          
+          cd public/apt
+          
+          # Generate Packages and Archives metadata
+          dpkg-scanpackages --arch amd64 pool/ > Packages
+          cat Packages | gzip -9c > Packages.gz
+          
+          # Generate base Release file
+          cat <<EOF > Release
+          Architectures: amd64
+          Codename: stable
+          Components: main
+          Date: $(date -Ru)
+          Description: Linuxy Official APT Repository
+          Label: Linuxy
+          Origin: swadhinbiswas
+          Suite: stable
+          EOF
+          
+          # Append Checksums to Release
+          echo "MD5Sum:" >> Release
+          for f in Packages Packages.gz; do
+            echo " $(md5sum $f | cut -d' ' -f1) $(stat -c %s $f) $f" >> Release
+          done
+          
+          echo "SHA1:" >> Release
+          for f in Packages Packages.gz; do
+            echo " $(sha1sum $f | cut -d' ' -f1) $(stat -c %s $f) $f" >> Release
+          done
+          
+          echo "SHA256:" >> Release
+          for f in Packages Packages.gz; do
+            echo " $(sha256sum $f | cut -d' ' -f1) $(stat -c %s $f) $f" >> Release
+          done
+
+      - name: Sign Repository (Optional if Keys Present)
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "Warning: GPG_PRIVATE_KEY secret is not set. The repository will be unsigned."
+            exit 0
+          fi
+          
+          echo "$GPG_PRIVATE_KEY" > private.key
+          gpg --batch --import private.key
+          rm private.key
+          
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ { print $5 }' | head -n 1)
+          echo "Found key: $KEY_ID"
+          
+          cd public/apt
+          
+          if [ -n "$GPG_PASSPHRASE" ]; then
+            echo "$GPG_PASSPHRASE" | gpg --default-key "$KEY_ID" --batch --yes --pinentry-mode loopback --passphrase-fd 0 -abs -o Release.gpg Release
+            echo "$GPG_PASSPHRASE" | gpg --default-key "$KEY_ID" --batch --yes --pinentry-mode loopback --passphrase-fd 0 --clearsign -o InRelease Release
+          else
+            gpg --default-key "$KEY_ID" --batch --yes -abs -o Release.gpg Release
+            gpg --default-key "$KEY_ID" --batch --yes --clearsign -o InRelease Release
+          fi
+          
+          # Export public key so users can download it
+          gpg --armor --export "$KEY_ID" > linuxy.gpg.key
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@
 
 ### Install from .deb (Debian / Ubuntu)
 
+#### Option 1: Official APT Repository (Recommended)
+Add the official repository to automatically receive updates via your package manager:
+```bash
+# Add the repository signing key
+curl -fsSL https://swadhinbiswas.github.io/linuxy/apt/linuxy.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/linuxy.gpg
+
+# Add the repository to sources
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/linuxy.gpg] https://swadhinbiswas.github.io/linuxy/apt /" | sudo tee /etc/apt/sources.list.d/linuxy.list
+
+# Install Linuxy
+sudo apt update
+sudo apt install linuxy
+```
+
+#### Option 2: Manual Download
 ```bash
 # Download the latest release
 wget https://github.com/swadhinbiswas/linuxy/releases/latest/download/linuxy_1.0.0_amd64.deb

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -12,7 +12,22 @@ Built automatically by Tauri. Supports:
 - Pop!_OS
 - Other Debian-based distributions
 
-**Installation:**
+**Installation via Custom APT Repository:**
+The easiest way to install and keep Linuxy updated is to add the official APT repository (hosted on GitHub Pages):
+
+```bash
+# Import the GPG key
+curl -fsSL https://swadhinbiswas.github.io/linuxy/apt/linuxy.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/linuxy.gpg
+
+# Add the repository
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/linuxy.gpg] https://swadhinbiswas.github.io/linuxy/apt /" | sudo tee /etc/apt/sources.list.d/linuxy.list
+
+# Update & Install
+sudo apt update
+sudo apt install linuxy
+```
+
+**Installation via Manual Download:**
 ```bash
 sudo apt install ./linuxy_*.deb
 ```


### PR DESCRIPTION
Resolves CI/CD distribution limits by engineering a fully independent, automated Debian package repository hosted directly on GitHub Pages.

Changes included:
- GitHub Actions Workflow (`apt-repo.yml`): Created a new pipeline that triggers post-release. It dynamically downloads all associated `.deb` assets, generates standard Debian repository architecture using `dpkg-dev`, and cryptographically signs the Release metadata using vault-stored GPG Secrets.
- Automated Deployment: Configured the workflow to securely publish the structured APT tree straight to the `gh-pages` branch for instant edge caching.
- Master Documentation (`README.md`): Overhauled the Installation section with step-by-step instructions for end-users to import the GPG public keyring and add the repository URL to their `sources.list.d`.
- Packaging Manual (`packaging/README.md`): Outlined the difference, and best practices, between the automated APT repository setup versus legacy manual downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established official APT repository with GPG signing for secure installation and updates on Debian/Ubuntu systems.

* **Documentation**
  * Updated installation guides featuring the new official APT repository as the recommended installation method with setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->