### PR TITLE
fix(release): resolve GitHub release upload and AUR package issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,12 +108,16 @@ jobs:
 
       - name: Upload DEB to release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: src-tauri/target/release/bundle/deb/*.deb
           draft: true
 
       - name: Upload RPM to release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: hashFiles('src-tauri/target/release/bundle/rpm/*.rpm') != ''
         with:
           files: src-tauri/target/release/bundle/rpm/*.rpm
@@ -133,21 +137,27 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Update PKGBUILD version
+      - name: Update PKGBUILD and .SRCINFO
         run: |
-          sed -i "s/pkgver=.*/pkgver=${{ steps.get_version.outputs.VERSION }}/" packaging/aur/PKGBUILD
-          sed -i "s|source = linuxy-.*|source = linuxy-${{ steps.get_version.outputs.VERSION }}.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v${{ steps.get_version.outputs.VERSION }}.tar.gz|" packaging/aur/.SRCINFO
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          sed -i "s/pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
+          sed -i "s/pkgver = .*/pkgver = ${VERSION}/" packaging/aur/.SRCINFO
+          sed -i "s|source = linuxy-.*|source = linuxy-${VERSION}.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v${VERSION}.tar.gz|" packaging/aur/.SRCINFO
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v2.7.1
         with:
           pkgname: linuxy
           pkgbuild: packaging/aur/PKGBUILD
+          assets: |
+            packaging/aur/.SRCINFO
+            packaging/aur/linuxy.install
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "chore: update to version ${{ steps.get_version.outputs.VERSION }}"
           ssh_keyscan_types: rsa,ed25519
+          updpkgsums: true
 
   notify:
     name: Notify Release

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = linuxy
 	pkgdesc = One-click Linux Application Manager with Firejail sandboxing
-	pkgver = 1.0.0
+	pkgver = 1.1.0
 	pkgrel = 1
 	url = https://github.com/swadhinbiswas/linuxy
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = linuxy
 	makedepends = cargo
 	makedepends = nodejs
 	makedepends = npm
-	source = linuxy-1.0.0.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v1.0.0.tar.gz
+	source = linuxy-1.1.0.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v1.1.0.tar.gz
 	sha256sums = SKIP
 
 pkgname = linuxy

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,7 +2,7 @@
 # AUR Package for Linuxy - One-click Linux Application Manager
 
 pkgname=linuxy
-pkgver=1.0.0
+pkgver=1.1.0
 pkgrel=1
 pkgdesc="One-click Linux Application Manager with Firejail sandboxing"
 arch=('x86_64')
@@ -38,7 +38,8 @@ package() {
   # Install icons
   install -Dm644 "src-tauri/icons/32x32.png" "$pkgdir/usr/share/icons/hicolor/32x32/apps/linuxy.png"
   install -Dm644 "src-tauri/icons/128x128.png" "$pkgdir/usr/share/icons/hicolor/128x128/apps/linuxy.png"
-  install -Dm644 "src-tauri/icons/128x128@2x.png" "$pkgdir/usr/share/icons/hicolor/256x256@2/apps/linuxy.png"
+  install -Dm644 "src-tauri/icons/128x128@2x.png" "$pkgdir/usr/share/icons/hicolor/256x256/apps/linuxy.png"
+  install -Dm644 "src-tauri/icons/icon.png" "$pkgdir/usr/share/icons/hicolor/512x512/apps/linuxy.png"
   
   # Install license
   install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/packaging/aur/linuxy.install
+++ b/packaging/aur/linuxy.install
@@ -9,7 +9,7 @@ post_install() {
   
   # Update icon cache
   if command -v gtk-update-icon-cache &> /dev/null; then
-    for size in 32x32 128x128 256x256; do
+    for size in 32x32 128x128 256x256 512x512; do
       gtk-update-icon-cache -f -t /usr/share/icons/hicolor/$size 2>/dev/null || true
     done
   fi
@@ -24,7 +24,7 @@ post_remove() {
   
   # Update icon cache
   if command -v gtk-update-icon-cache &> /dev/null; then
-    for size in 32x32 128x128 256x256; do
+    for size in 32x32 128x128 256x256 512x512; do
       gtk-update-icon-cache -f -t /usr/share/icons/hicolor/$size 2>/dev/null || true
     done
   fi


### PR DESCRIPTION
## Summary
- Fix missing GITHUB_TOKEN in release asset upload steps (DEB/RPM were failing to upload to GitHub Releases)
- Update AUR package versions from 1.0.0 to 1.1.0 in both PKGBUILD and .SRCINFO
- Fix release workflow to properly update pkgver in both PKGBUILD and .SRCINFO during automated AUR publishing
- Include .SRCINFO and linuxy.install as assets when publishing to AUR
- Enable updpkgsums for proper checksum generation instead of SKIP
- Fix icon paths to use standard hicolor directories (256x256 instead of non-standard 256x256@2)
- Add 512x512 icon installation and cache updates

## Related Issues
Fixes release package upload failures to GitHub Releases
Fixes AUR package version mismatch and missing checksums

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 512x512 icon support for improved display quality across different screen sizes.

* **Bug Fixes**
  * Corrected icon installation paths for proper system integration.

* **Chores**
  * Enhanced release workflow for improved package metadata and asset handling.
  * Version bumped to 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->