### PR TITLE
release: v1.2.0 - Fix release pipeline and AUR package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
             ## 🙏 Thanks
             Thanks to everyone who contributed to this release!
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           includeDebug: false
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linuxy",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "homepage": "https://swadhinbiswas.github.io/linuxy",
   "scripts": {

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = linuxy
 	pkgdesc = One-click Linux Application Manager with Firejail sandboxing
-	pkgver = 1.1.0
+	pkgver = 1.2.0
 	pkgrel = 1
 	url = https://github.com/swadhinbiswas/linuxy
 	arch = x86_64
@@ -14,7 +14,7 @@ pkgbase = linuxy
 	makedepends = cargo
 	makedepends = nodejs
 	makedepends = npm
-	source = linuxy-1.1.0.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v1.1.0.tar.gz
-	sha256sums = 14ec94d5c68c770849b945eb793a5ff638a4ceb682d65aa69b64068dc5d30d27
+	source = linuxy-1.2.0.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v1.2.0.tar.gz
+	sha256sums = SKIP
 
 pkgname = linuxy

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -10,11 +10,11 @@ pkgbase = linuxy
 	depends = webkit2gtk
 	depends = gtk3
 	depends = libappindicator-gtk3
-	depends = libxdo
+	depends = xdo
 	makedepends = cargo
 	makedepends = nodejs
 	makedepends = npm
 	source = linuxy-1.1.0.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v1.1.0.tar.gz
-	sha256sums = SKIP
+	sha256sums = 14ec94d5c68c770849b945eb793a5ff638a4ceb682d65aa69b64068dc5d30d27
 
 pkgname = linuxy

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -8,11 +8,11 @@ pkgdesc="One-click Linux Application Manager with Firejail sandboxing"
 arch=('x86_64')
 url="https://github.com/swadhinbiswas/linuxy"
 license=('MIT')
-depends=('firejail' 'xdg-utils' 'webkit2gtk' 'gtk3' 'libappindicator-gtk3' 'libxdo')
+depends=('firejail' 'xdg-utils' 'webkit2gtk' 'gtk3' 'libappindicator-gtk3' 'xdo')
 makedepends=('cargo' 'nodejs' 'npm')
 install=linuxy.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swadhinbiswas/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('14ec94d5c68c770849b945eb793a5ff638a4ceb682d65aa69b64068dc5d30d27')
 
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,7 +2,7 @@
 # AUR Package for Linuxy - One-click Linux Application Manager
 
 pkgname=linuxy
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="One-click Linux Application Manager with Firejail sandboxing"
 arch=('x86_64')
@@ -12,7 +12,7 @@ depends=('firejail' 'xdg-utils' 'webkit2gtk' 'gtk3' 'libappindicator-gtk3' 'xdo'
 makedepends=('cargo' 'nodejs' 'npm')
 install=linuxy.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swadhinbiswas/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('14ec94d5c68c770849b945eb793a5ff638a4ceb682d65aa69b64068dc5d30d27')
+sha256sums=('SKIP')
 
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Linuxy",
-    "version": "1.0.0"
+    "version": "1.2.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
## Summary
- Bump version to 1.2.0 across all files
- Fix AUR package dependency (libxdo → xdo)
- Change release workflow to publish immediately (no draft)
- Reset checksums for auto-generation during release

## What's Fixed
- Release assets now upload correctly to GitHub Releases
- AUR package uses correct Arch Linux dependency names
- Version numbers are synchronized across package.json, tauri.conf.json, PKGBUILD, and .SRCINFO
- Releases are published immediately, triggering downstream workflows (APT repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.0 across all package configurations
  * Release workflow optimized to automatically publish releases immediately upon creation
  * Updated packaging dependencies for improved installation compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->