### PR TITLE
fix(aur): add proper checksums and remove updpkgsums to avoid AUR blob size limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,11 @@ jobs:
           sed -i "s/pkgver=.*/pkgver=${VERSION}/" packaging/aur/PKGBUILD
           sed -i "s/pkgver = .*/pkgver = ${VERSION}/" packaging/aur/.SRCINFO
           sed -i "s|source = linuxy-.*|source = linuxy-${VERSION}.tar.gz::https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v${VERSION}.tar.gz|" packaging/aur/.SRCINFO
+          # Download source and compute checksum
+          curl -sL "https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v${VERSION}.tar.gz" -o /tmp/linuxy-${VERSION}.tar.gz
+          CHECKSUM=$(sha256sum /tmp/linuxy-${VERSION}.tar.gz | awk '{print $1}')
+          sed -i "s/sha256sums=.*/sha256sums=('${CHECKSUM}')/" packaging/aur/PKGBUILD
+          sed -i "s/sha256sums = .*/sha256sums = ${CHECKSUM}/" packaging/aur/.SRCINFO
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v2.7.1
@@ -157,7 +162,6 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "chore: update to version ${{ steps.get_version.outputs.VERSION }}"
           ssh_keyscan_types: rsa,ed25519
-          updpkgsums: true
 
   notify:
     name: Notify Release

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -12,7 +12,7 @@ depends=('firejail' 'xdg-utils' 'webkit2gtk' 'gtk3' 'libappindicator-gtk3' 'xdo'
 makedepends=('cargo' 'nodejs' 'npm')
 install=linuxy.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/swadhinbiswas/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('76b293fb2b2517248f0259dc3bd0602655f45730724290dbf405ad1fe0e23f02')
 
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary\n- Add pre-computed SHA256 checksum for v1.2.0 source tarball\n- Remove `updpkgsums: true` from AUR publish step (downloads 36MB tarball, exceeds AUR's 500KB blob limit)\n- Add checksum computation step in release workflow that downloads source and updates PKGBUILD/.SRCINFO before publishing