### PR TITLE
chore(release): bump version to 2.0.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+linuxy (2.0.4-1) unstable; urgency=medium
+
+  * Fix all CodeRabbit review findings (PR #41) - security, packaging, CI
+  * Harden desktop entry handling, sandboxing, and storage cleanup
+  * Fix Flatpak, AppImage, and cross-platform installer issues
+  * Improve CI/CD, dependency handling, and formatting
+  * Update to Bun, fix Tauri 2 integration, and harden scripts
+
+ -- Swadhin Biswas <swadhin.biswas@example.com>  Sat, 29 Aug 2026 00:00:00 +0000
+
 linuxy (2.0.0-1) unstable; urgency=medium
 
   * Tauri 2.0 migration with cross-platform support

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         linuxy = pkgs.stdenv.mkDerivation rec {
           pname = "linuxy";
-          version = "2.0.0";
+          version = "2.0.4";
           src = self;
 
           nativeBuildInputs = with pkgs; [

--- a/flatpak/com.linuxy.App.yaml
+++ b/flatpak/com.linuxy.App.yaml
@@ -55,7 +55,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/swadhinbiswas/linuxy
-        tag: v2.0.1
+        tag: v2.0.4
         commit: 744b5349d6cd734debe2d869a2362f732f238e91
         x-checker-data:
           type: git

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linuxy",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "homepage": "https://swadhinbiswas.github.io/linuxy",
   "scripts": {

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -2,7 +2,7 @@
 # Alpine Linux APKBUILD for Linuxy
 
 pkgname=linuxy
-pkgver=2.0.0
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="Multi-platform Desktop Application Manager with Firejail sandboxing"
 url="https://github.com/swadhinbiswas/linuxy"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -3,7 +3,7 @@
 # AUR Package for Linuxy - One-click Linux Application Manager
 
 pkgname=linuxy
-pkgver=2.0.0
+pkgver=2.0.4
 pkgrel=1
 pkgdesc="Multi-platform Desktop Application Manager with Firejail sandboxing"
 arch=('x86_64' 'aarch64')

--- a/packaging/gentoo/linuxy-2.0.4.ebuild
+++ b/packaging/gentoo/linuxy-2.0.4.ebuild
@@ -1,0 +1,77 @@
+# Copyright 2026 Swadhin Biswas
+# Distributed under the terms of the MIT License
+
+EAPI=8
+
+inherit cargo desktop xdg
+
+DESCRIPTION="Multi-platform Desktop Application Manager with Firejail sandboxing"
+HOMEPAGE="https://github.com/swadhinbiswas/linuxy"
+SRC_URI="https://github.com/swadhinbiswas/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+IUSE=""
+
+DEPEND="
+	dev-libs/openssl
+	dev-libs/glib:2
+	net-libs/webkit-gtk:4.1
+	x11-libs/gtk+:3
+	x11-libs/libX11
+	x11-libs/libxdo
+	app-admin/firejail
+	x11-misc/xdg-utils
+	gnome-base/librsvg
+	dev-libs/libappindicator:3
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	>=virtual/rust-1.80
+	net-libs/nodejs
+	sys-devel/clang
+"
+
+QA_FLAGS_IGNORED="usr/bin/${PN}"
+
+src_prepare() {
+	default
+	npm install
+}
+
+src_configure() {
+	:
+}
+
+src_compile() {
+	npm run build
+	cd src-tauri
+	cargo build --release
+}
+
+src_install() {
+	dobin src-tauri/target/release/linuxy
+	domenu src-tauri/debian/desktop-template.desktop
+	doicon src-tauri/icons/icon.png
+
+	for size in 32 128 256 512; do
+		icon="src-tauri/icons/${size}x${size}.png"
+		if [ -f "$icon" ]; then
+			newicon -s ${size} "$icon" linuxy.png || die
+		fi
+	done
+
+	dodoc README.md
+	dolicense LICENSE
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}

--- a/packaging/rpm/linuxy.spec
+++ b/packaging/rpm/linuxy.spec
@@ -1,5 +1,5 @@
 Name:           linuxy
-Version:        2.0.0
+Version:        2.0.4
 Release:        1%{?dist}
 Summary:        Multi-platform Desktop Application Manager
 
@@ -70,6 +70,11 @@ install -Dm644 LICENSE %{buildroot}%{_datadir}/licenses/linuxy/LICENSE
 %doc README.md
 
 %changelog
+* Sat Aug 29 2026 Swadhin Biswas <swadhin.biswas@example.com> - 2.0.4-1
+- Fix all CodeRabbit review findings (PR #41)
+- Harden desktop entry handling and storage cleanup
+- Fix packaging and CI/CD
+
 * Mon Jun 24 2026 Swadhin Biswas <swadhin.biswas@example.com> - 2.0.0-1
 - Tauri 2.0 migration with cross-platform support
 - Added Windows and macOS support

--- a/packaging/solus/pspec.xml
+++ b/packaging/solus/pspec.xml
@@ -14,7 +14,7 @@
 that lets you discover, install, and manage desktop applications
 with optional Firejail sandboxing for enhanced security.</Description>
     <Archive type="tarball" sha256sum="SKIP">
-      <URI>https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v2.0.0.tar.gz</URI>
+      <URI>https://github.com/swadhinbiswas/linuxy/archive/refs/tags/v2.0.4.tar.gz</URI>
     </Archive>
     <BuildDependencies>
       <Dependency>cargo</Dependency>

--- a/packaging/solus/pspec_patch.xml
+++ b/packaging/solus/pspec_patch.xml
@@ -5,7 +5,7 @@
     <Name>linuxy</Name>
     <History>
       <Update release="1" date="2026-06-24">
-        <Version>2.0.0</Version>
+        <Version>2.0.4</Version>
         <Comment>Tauri 2.0 migration with cross-platform support</Comment>
         <Name>Swadhin Biswas</Name>
         <Email>swadhin.biswas@example.com</Email>

--- a/packaging/void/template
+++ b/packaging/void/template
@@ -1,6 +1,6 @@
 # Template file for 'linuxy'
 pkgname=linuxy
-version=2.0.0
+version=2.0.4
 revision=1
 build_style=cargo
 make_cmd=cargo

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: linuxy
-version: "1.2.0"
+version: "2.0.4"
 summary: One-click Linux Application Manager
 description: |
   Linuxy is a modern Linux application manager with one-click installation,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linuxy"
-version = "2.0.3"
+version = "2.0.4"
 description = "A centralized application manager for Linux, Windows, and macOS"
 authors = ["Swadhin Biswas <swadhinbiswas.cse@gmail.com>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Linuxy",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "identifier": "com.linuxy.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release v2.0.4

- Bump version to 2.0.4 in package.json, Cargo.toml, tauri.conf.json
- Update packaging (AUR, Alpine, RPM, Solus, Void, Gentoo, Snap, Flake, Flatpak)
- Add debian/changelog entry
- Includes all CodeRabbit fixes from PR #41

Ready for tag v2.0.4 and release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released Linuxy version 2.0.4 with updated version information across supported distribution packages.
  * Added release changelog details covering security, packaging, installer, sandboxing, storage cleanup, and build improvements.

* **New Distribution Support**
  * Added Gentoo packaging for Linuxy, including desktop integration, icons, documentation, and cache updates.

* **Packaging**
  * Updated Flatpak, Snap, Alpine, Arch, Fedora, Solus, Void, and Nix package metadata to version 2.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->